### PR TITLE
Migrate the database to PostgreSQL

### DIFF
--- a/DummyReadme.md
+++ b/DummyReadme.md
@@ -65,7 +65,41 @@ python ./easyreadweb/manage.py makemigrations
 python ./easyreadweb/manage.py migrate
 ```
 
-8. Run the server
+8. Install PostgreSQL 16.9-1  
+Download and install PostgreSql 16.9 from official website
+Add psql bin to path
+On Mac:
+```
+echo 'export PATH="/Library/PostgreSQL/16/bin:$PATH"' >> ~/.zshrc
+```
+
+Test psql version and successfully installed:
+```
+psql --version
+```
+
+Run the following in the terminal:
+```
+psql -U postgres
+(enter the admin password you set during setup of postgreSql)
+CREATE DATABASE easyread;
+CREATE USER easyreaddj WITH PASSWORD 'your_password'; 
+(WARNING: Please change password here for security and under easyreadweb/easyreadweb/settings.py object DATABASES{'PASSWORD': 'your_password'})
+GRANT ALL PRIVILEGES ON DATABASE easyread TO easyreaddj;
+\c easyread
+GRANT ALL ON SCHEMA public TO easyreaddj;
+ALTER SCHEMA public OWNER TO easyreaddj;
+\q
+```
+
+Start migrate the db to PostgreSql
+```
+python ./easyreadweb/manage.py migrate
+```
+
+
+
+9. Run the server
 
 Django
 ```

--- a/easyreadweb/easyreadweb/settings.py
+++ b/easyreadweb/easyreadweb/settings.py
@@ -78,10 +78,23 @@ WSGI_APPLICATION = "easyreadweb.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
+# sqlite3 (retired)
+# DATABASES = {
+#     "default": {
+#         "ENGINE": "django.db.backends.sqlite3",
+#         "NAME": BASE_DIR / ".." / "instance" / "djsite.db",
+#     }
+# }
+
+# PostgreSql 16.9
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / ".." / "instance" / "djsite.db",
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'easyread',
+        'USER': 'easyreaddj',
+        'PASSWORD': 'your_password',
+        'HOST': 'localhost',
+        'PORT': '5432',
     }
 }
 


### PR DESCRIPTION
Bullet points:

- Add server migration introduction and scripts
- Add configuration in settings.py

This pull request introduces changes to migrate the database from SQLite to PostgreSQL for the `easyreadweb` project. The updates include instructions for setting up PostgreSQL and modifying the database configuration in the Django settings file.

Database migration setup:

* [`DummyReadme.md`](diffhunk://#diff-bb0d9ff3f34a0c9c573e48c31983139b80637040ba7467656d079e659d7cd1d7L68-R102): Added detailed steps for installing PostgreSQL 16.9, configuring the database, creating a user, and granting privileges. Instructions include testing the PostgreSQL installation and migrating the database using Django's `manage.py`.

Database configuration updates:

* [`easyreadweb/easyreadweb/settings.py`](diffhunk://#diff-ce67f6c94a8ebd645f3008ee4646c938760369ee65167ee5234af86d8a99017cR81-R97): Replaced the SQLite database configuration with PostgreSQL settings, including database name, user, password, host, and port. Deprecated the SQLite configuration by commenting it out.